### PR TITLE
Improve types to base what `visitor` gets on `tree`

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ const empty = []
 export const remove =
   /**
    * @type {(
-   *  (<Tree extends Node>(node: Tree, options: RemoveOptions, test: Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>|Array<Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>>) => Tree|null) &
-   *  (<Tree extends Node>(node: Tree, test: Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>|Array<Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>>) => Tree|null)
+   *  (<Tree extends Node>(node: Tree, options: RemoveOptions, test: Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').InclusiveDescendant<Tree>>|Array<Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').InclusiveDescendant<Tree>>>) => Tree|null) &
+   *  (<Tree extends Node>(node: Tree, test: Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').InclusiveDescendant<Tree>>|Array<Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').InclusiveDescendant<Tree>>>) => Tree|null)
    * )}
    */
   (

--- a/index.js
+++ b/index.js
@@ -4,7 +4,17 @@
  *
  * @typedef {import('unist-util-is').Type} Type
  * @typedef {import('unist-util-is').Props} Props
- * @typedef {import('unist-util-is').TestFunctionAnything} TestFunctionAnything
+ */
+
+/**
+ * Check if a node passes a test
+ *
+ * @template {Node} Tree Node type that is checked.
+ * @callback TestFunction
+ * @param {Tree} node
+ * @param {number|null|undefined} [index]
+ * @param {Parent|null|undefined} [parent]
+ * @returns {boolean|void}
  */
 
 /**
@@ -20,8 +30,8 @@ const empty = []
 export const remove =
   /**
    * @type {(
-   *  (<T extends Node>(node: T, options: RemoveOptions, test: Type|Props|TestFunctionAnything|Array<Type|Props|TestFunctionAnything>) => T|null) &
-   *  (<T extends Node>(node: T, test: Type|Props|TestFunctionAnything|Array<Type|Props|TestFunctionAnything>) => T|null)
+   *  (<Tree extends Node>(node: Tree, options: RemoveOptions, test: Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>|Array<Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>>) => Tree|null) &
+   *  (<Tree extends Node>(node: Tree, test: Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>|Array<Type|Props|TestFunction<import('unist-util-visit-parents/complex-types').NodeInTree<Tree>>>) => Tree|null)
    * )}
    */
   (
@@ -31,7 +41,7 @@ export const remove =
      *
      * @param {Node} tree Tree to filter
      * @param {RemoveOptions} options Whether to drop parent nodes if they had children, but all their children were filtered out. Default is `{cascade: true}`
-     * @param {Type|Props|TestFunctionAnything|Array<Type|Props|TestFunctionAnything>} test is-compatible test (such as a type)
+     * @param {Type|Props|TestFunction<Node>|Array<Type|Props|TestFunction<Node>>} test is-compatible test (such as a type)
      * @returns {Node|null}
      */
     function (tree, options, test) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   ],
   "dependencies": {
     "@types/unist": "^2.0.0",
-    "unist-util-is": "^5.0.0"
+    "unist-util-is": "^5.0.0",
+    "unist-util-visit-parents": "^3.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@types/unist": "^2.0.0",
     "unist-util-is": "^5.0.0",
-    "unist-util-visit-parents": "^3.0.0"
+    "unist-util-visit-parents": "^5.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

See https://github.com/syntax-tree/unist-util-visit-parents/pull/10.

<!--do not edit: pr-->
